### PR TITLE
Exclude unnecessary files from package

### DIFF
--- a/Source/EngageBooking.Build
+++ b/Source/EngageBooking.Build
@@ -332,6 +332,8 @@
     <exclude name="_ReSharper.*/**"/>
     <exclude name="**/obj/**"/>
     <exclude name="${referencesDirectory}/**"/>
+    <exclude name="**/bin/**"/>
+    <exclude name="CustomDictionary.xml"/>
   </patternset>
   <patternset id="source.fileset">
     <include name="**/*.js"/>
@@ -353,6 +355,7 @@
     <include name="??.??.??.txt" />
     <include name="MSBuild/*.dll"/>
     <include name="MSBuild/*.targets"/>
+    <include name="CustomDictionary.xml"/>
     <exclude name="**/obj/**"/>
     <exclude name="Release.txt"/>
   </patternset>


### PR DESCRIPTION
Excluding 'bin' folder and 'CustomDictionary.xml' from Resources.zip in the install package.
